### PR TITLE
Enable workspace feature and update welcome text

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -345,10 +345,14 @@
 # Set the value to true to enable workspace feature
 # Please note, workspace will not work with multi-tenancy. To enable workspace feature, you need to disable multi-tenancy first with `opensearch_security.multitenancy.enabled: false`
 # Please uncomment below uiSettings to enable new home/navigation experience when workspace is enabled
-# workspace.enabled: false
-# uiSettings:
-#   overrides:
-#     "home:useNewHomePage": true
+# Disable multi-tenancy to allow workspace feature
+opensearch_security.multitenancy.enabled: false
+
+# Enable workspace feature
+workspace.enabled: true
+uiSettings:
+  overrides:
+    "home:useNewHomePage": true
 
 # Set a maximum number of workspaces
 # by default, there is no limit.

--- a/src/plugins/workspace/public/components/workspace_initial/__snapshots__/workspace_initial.test.tsx.snap
+++ b/src/plugins/workspace/public/components/workspace_initial/__snapshots__/workspace_initial.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`WorkspaceInitial render workspace initial page normally when user is OS
               <h1
                 class="euiTitle euiTitle--large"
               >
-                Welcome to OpenSearch
+                Welcome to OpenSearch Dashboards
               </h1>
             </div>
             <div
@@ -760,7 +760,7 @@ exports[`WorkspaceInitial render workspace initial page normally when user is no
               <h1
                 class="euiTitle euiTitle--large"
               >
-                Welcome to OpenSearch
+                Welcome to OpenSearch Dashboards
               </h1>
             </div>
             <div

--- a/src/plugins/workspace/public/components/workspace_initial/workspace_initial.tsx
+++ b/src/plugins/workspace/public/components/workspace_initial/workspace_initial.tsx
@@ -150,7 +150,7 @@ export const WorkspaceInitial = ({ registeredUseCases$ }: WorkspaceInitialProps)
         <EuiTitle size="l">
           <h1>
             {i18n.translate('workspace.initial.title', {
-              defaultMessage: 'Welcome to OpenSearch',
+              defaultMessage: 'Welcome to OpenSearch Dashboards',
             })}
           </h1>
         </EuiTitle>

--- a/test/functional/apps/visualize/_custom_branding.ts
+++ b/test/functional/apps/visualize/_custom_branding.ts
@@ -25,7 +25,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const expectedMarkLogoDarkMode =
     'https://opensearch.org/wp-content/uploads/2025/01/opensearch_mark_darkmode.svg';
   const applicationTitle = 'OpenSearch';
-  const expectedWelcomeMessage = 'Welcome to OpenSearch';
+  const expectedWelcomeMessage = 'Welcome to OpenSearch Dashboards';
 
   describe('OpenSearch Dashboards branding configuration', function customHomeBranding() {
     describe('should render overview page', async () => {


### PR DESCRIPTION
## Summary
- enable workspaces in default config
- update workspace initial header to show "Welcome to OpenSearch Dashboards"
- align functional tests and snapshots with new text

## Testing
- `yarn test:jest src/plugins/workspace/public/components/workspace_initial/workspace_initial.test.tsx` *(fails: The engine "node" is incompatible)*

------
https://chatgpt.com/codex/tasks/task_e_6845fe9568ac832d8ebb0dc5dc1f6f32